### PR TITLE
Add an example of a compound expression in a slice

### DIFF
--- a/basic_syntax.md
+++ b/basic_syntax.md
@@ -65,7 +65,7 @@ html! {
 }
 ```
 
-Use `(foo)` syntax to splice in the value of `foo` at runtime. Any HTML special characters are escaped by default. Arbitrary Rust code can be included in a compound expression when there is complicated work to be done or type inference needs a little bit of help:
+Use `(foo)` syntax to splice in the value of `foo` at runtime. Any HTML special characters are escaped by default. Arbitrary Rust code can be included in a compound expression when a single expression would be hard to read or when Rust's type inference needs a little bit of help:
 
 ```rust
 html! {

--- a/basic_syntax.md
+++ b/basic_syntax.md
@@ -65,7 +65,17 @@ html! {
 }
 ```
 
-Use `(foo)` syntax to splice in the value of `foo` at runtime. Any HTML special characters are escaped by default.
+Use `(foo)` syntax to splice in the value of `foo` at runtime. Any HTML special characters are escaped by default. Arbitrary Rust code can be included in a compound expression when there is complicated work to be done or type inference needs a little bit of help:
+
+```rust
+html! {
+    p ({
+        let f:Foo = try![something()];
+        let b = f.get_bar::<Bar>();
+        b.start_time().format("%H%Mh")
+    })
+}
+```
 
 You can splice any value that implements [`std::fmt::Display`][Display]. Most primitive types (such as `str` and `i32`) implement this trait, so they should work out of the box. To change this behavior for some type, you can implement the [`Render`][Render] trait by hand. See the [traits](./traits.md) section for details.
 

--- a/basic_syntax.md
+++ b/basic_syntax.md
@@ -65,17 +65,18 @@ html! {
 }
 ```
 
-Use `(foo)` syntax to splice in the value of `foo` at runtime. Any HTML special characters are escaped by default. Arbitrary Rust code can be included in a compound expression when a single expression would be hard to read or when Rust's type inference needs a little bit of help:
+Use `(foo)` syntax to splice in the value of `foo` at runtime. Any HTML special characters are escaped by default.
 
 ```rust
 html! {
     p ({
-        let f:Foo = try![something()];
-        let b = f.get_bar::<Bar>();
-        b.start_time().format("%H%Mh")
+        let f: Foo = something_convertible_to_foo()?;
+        f.time().format("%H%Mh")
     })
 }
 ```
+
+Arbitrary Rust code can be included in a slice by using a [block](https://doc.rust-lang.org/reference.html#block-expressions). This can be helpful for complex expressions that would be difficult to read otherwise. It is also helpful when Rust's type inference needs a little bit of help (e.g., convert this to a `Foo` using `From<Foo>` in the example above).
 
 You can splice any value that implements [`std::fmt::Display`][Display]. Most primitive types (such as `str` and `i32`) implement this trait, so they should work out of the box. To change this behavior for some type, you can implement the [`Render`][Render] trait by hand. See the [traits](./traits.md) section for details.
 


### PR DESCRIPTION
Slices can contain compound expressions, which can be used to bring in arbitrary Rust code. It has been possible to glean this by reading between the lines, but it could be helpful to make it more explicit and provide an example.