### PR TITLE
Fix Rocket example for 0.3

### DIFF
--- a/web_frameworks.md
+++ b/web_frameworks.md
@@ -66,9 +66,10 @@ extern crate maud;
 extern crate rocket;
 
 use maud::{html, Markup};
+use std::borrow::Cow;
 
 #[get("/<name>")]
-fn hello(name: &str) -> Markup {
+fn hello<'a>(name: Cow<'a, str>) -> Markup {
     html! {
         h1 { "Hello, " (name) "!" }
         p "Nice to meet you!"


### PR DESCRIPTION
Rocket made [this change](https://github.com/SergioBenitez/Rocket/commit/f5ec470a7d8b24a031fc9201679329ca2a524fde) for 0.3, which Maud has dependend against for a while. It breaks the Rocket example in the book that uses `&str` which no longer implements `FromParam`.  The other options besides Cow strs that could be used are RawStr (a direct mapping) or String, but I felt Cow was probably the intent of the example.