### PR TITLE
Document html composability clearly (aka partials)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -4,6 +4,7 @@
 * [Getting started](getting_started.md)
 * [Basic syntax](basic_syntax.md)
 * [Dynamic content](dynamic_content.md)
+* [Partials](partials.md)
 * [Control structures](control_structures.md)
 * [The `Render` trait](traits.md)
 * [Web framework integration](web_frameworks.md)

--- a/partials.md
+++ b/partials.md
@@ -4,8 +4,6 @@ Maud does not have a built-in concept of partials or sub-templates. Instead, you
 
 The following example uses a `header` and `footer` function that are used in the `page` function to return a final result.
 
-Here is a page that has a dynamic page title, a body and a footer with an RSS link:
-
 ```rust
 extern crate maud;
 
@@ -34,12 +32,15 @@ fn footer() -> Markup {
 }
 
 /// The final Markup, including `header` and `footer`.
-pub fn page(title: &str) -> Markup {
+///
+/// Additionally takes a `greeting_box` that's `Markup`, not `&str`.
+pub fn page(title: &str, greeting_box: Markup) -> Markup {
     html! {
         // Add the header markup to the page
         (header(title))
         body {
             h1 { "Hello World" }
+            (greeting_box)
         }
         // Add the footer markup to the page
         (footer())
@@ -47,4 +48,12 @@ pub fn page(title: &str) -> Markup {
 }
 ```
 
-Calling `page` with a title will then return the markup for the whole page.
+Using the `page` function will return the markup for the whole page and looks like this:
+
+```rust
+fn main() {
+    page("Hello!", html! {
+        div { "Greetings, Maud." }
+    });
+}
+```

--- a/partials.md
+++ b/partials.md
@@ -1,8 +1,8 @@
 # Partials
 
-Maud does not have a built-in concept of partials or sub templates. Instead, you can compose your markup with any function that returns `Markup`.
+Maud does not have a built-in concept of partials or sub-templates. Instead, you can compose your markup with any function that returns `Markup`.
 
-The following uses a `header` and `footer` function that are used in the `page` function to return a final result.
+The following example uses a `header` and `footer` function that are used in the `page` function to return a final result.
 
 Here is a page that has a dynamic page title, a body and a footer with an RSS link:
 

--- a/partials.md
+++ b/partials.md
@@ -1,0 +1,50 @@
+# Partials
+
+Maud does not have a built-in concept of partials or sub templates. Instead, you can compose your markup with any function that returns `Markup`.
+
+The following uses a `header` and `footer` function that are used in the `page` function to return a final result.
+
+Here is a page that has a dynamic page title, a body and a footer with an RSS link:
+
+```rust
+extern crate maud;
+
+use self::maud::{DOCTYPE, html, Markup};
+
+/// A basic header with a dynamic `page_title`.
+fn header(page_title: &str) -> Markup {
+    html! {
+        (DOCTYPE)
+        html {
+            meta charset="utf-8";
+            title { (page_title) }
+        }
+    }
+}
+
+/// A static footer.
+fn footer() -> Markup {
+    html! {
+        footer {
+            span {
+                a href="rss.atom" { "RSS Feed" }
+            }
+        }
+    }
+}
+
+/// The final Markup, including `header` and `footer`.
+pub fn page(title: &str) -> Markup {
+    html! {
+        // Add the header markup to the page
+        (header(title))
+        body {
+            h1 { "Hello World" }
+        }
+        // Add the footer markup to the page
+        (footer())
+    }
+}
+```
+
+Calling `page` with a title will then return the markup for the whole page.


### PR DESCRIPTION
When I was evaluating maud, I ran into the [same issue](https://github.com/lfairy/maud/issues/133) as @max-frai regarding partials/sub templates. This documents that it's super easy to compose the templates using plain Rust functions.

Closes https://github.com/lfairy/maud/issues/133